### PR TITLE
fix exception naming Excited → Exceeded

### DIFF
--- a/ansq/utils.py
+++ b/ansq/utils.py
@@ -69,7 +69,7 @@ def _convert_to_str(value):
     return converted_value
 
 
-class MaxRetriesExcited(Exception):
+class MaxRetriesExceeded(Exception):
     pass
 
 


### PR DESCRIPTION
In english Excited is "very enthusiastic and eager." while Exceeded is "go beyond what is allowed or stipulated by (a set limit)."