### PR TITLE
Catch `writer.wait_closed()` exception to avoid command hanging. #33

### DIFF
--- a/ansq/tcp/connection.py
+++ b/ansq/tcp/connection.py
@@ -124,8 +124,8 @@ class NSQConnection(NSQConnectionBase):
             self._writer.close()
             if sys.version_info >= (3, 7):
                 await self._writer.wait_closed()
-        finally:
-            pass
+        except Exception as e:
+            self.logger.exception(e)
 
         for future, callback in self._cmd_waiters:
             if not future.cancelled():


### PR DESCRIPTION
Fixes #33 

As asyncio docs says about `StreamWriter.write` method:

> The method attempts to write the data to the underlying socket immediately. If that fails, the data is queued in an internal write buffer until it can be sent.

Also, `wait_closed` is writing data left in buffer before exiting

However, in library code any exception in `wait_closed` is ignored:

https://github.com/list-family/ansq/blob/cb4c7226abdff72789999ae65cac8746be0465c7/ansq/tcp/connection.py#L122-L128

And code intended to _unhang_ command located below is never reached

https://github.com/list-family/ansq/blob/cb4c7226abdff72789999ae65cac8746be0465c7/ansq/tcp/connection.py#L130-L133
