### PR TITLE
Truncate response data in debug log

### DIFF
--- a/ansq/tcp/connection.py
+++ b/ansq/tcp/connection.py
@@ -23,7 +23,7 @@ from ansq.tcp.types import (
 )
 from ansq.tcp.types import TCPConnection as NSQConnectionBase
 from ansq.typedefs import TCPResponse
-from ansq.utils import validate_topic_channel_name
+from ansq.utils import truncate_text, validate_topic_channel_name
 
 
 class NSQConnection(NSQConnectionBase):
@@ -295,7 +295,7 @@ class NSQConnection(NSQConnectionBase):
             await self._pulse()
             return True
 
-        self.logger.debug("NSQ: Got data: %s", response)
+        self.logger.debug("NSQ: Got data: %s", truncate_text(str(response)))
 
         if response.is_message:
             assert isinstance(response, NSQMessageSchema)

--- a/ansq/utils.py
+++ b/ansq/utils.py
@@ -177,3 +177,11 @@ def get_logger(
     logging.basicConfig(format=log_format)
     logger.setLevel(logging.DEBUG if debug else logging.INFO)
     return logger
+
+
+def truncate_text(text: str, limit: int = 256) -> str:
+    """Truncate a given `text` if the `limit` is reached"""
+    if limit <= 0:
+        raise ValueError("limit must be greater than 0")
+
+    return text[:limit] + "..." if len(text) > limit else text

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,29 @@
+import pytest
+
+from ansq.utils import truncate_text
+
+
+@pytest.mark.parametrize(
+    "text, limit, expected",
+    (
+        pytest.param("0123456789", 11, "0123456789", id="no trunc, greater than limit"),
+        pytest.param("0123456789", 10, "0123456789", id="no trunc, equal limit"),
+        pytest.param("0123456789", 9, "012345678...", id="trunc"),
+        pytest.param("0123456789", 1, "0...", id="minimal trunc"),
+        pytest.param("", 10, "", id="empty string"),
+    ),
+)
+def test_truncate_text(text, limit, expected):
+    assert truncate_text(text, limit) == expected
+
+
+@pytest.mark.parametrize(
+    "text, limit",
+    (
+        pytest.param("0123456789", 0, id="zero"),
+        pytest.param("0123456789", -1, id="negative"),
+    ),
+)
+def test_truncate_text_raises_value_error(text, limit):
+    with pytest.raises(ValueError, match=r"^limit must be greater than 0$"):
+        assert truncate_text(text, limit)


### PR DESCRIPTION
The response data should be limited to a reasonable amount of data, otherwise, if a user who processing large messages would have a large log file pretty quickly.