### PR TITLE
Drop support for EOL Python 3.6

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -16,7 +16,6 @@ jobs:
         os:
           - Ubuntu
         python-version:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,14 +8,14 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v2.1.0
+    rev: v2.2.0
     hooks:
       - id: setup-cfg-fmt
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.1.0
+    rev: v3.2.0
     hooks:
     - id: pyupgrade
-      args: [--py36-plus]
+      args: [--py37-plus]
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:

--- a/ansq/tcp/connection.py
+++ b/ansq/tcp/connection.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-import sys
 import warnings
 from datetime import datetime, timezone
 from typing import Any, AsyncGenerator, Callable, Mapping, Optional, Union
@@ -176,8 +175,7 @@ class NSQConnection(NSQConnectionBase):
         assert self._writer is not None
         try:
             self._writer.close()
-            if sys.version_info >= (3, 7):
-                await self._writer.wait_closed()
+            await self._writer.wait_closed()
         except Exception as e:
             self.logger.exception(e)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 aiohttp==3.7.4
-async-generator==1.10  # TODO: uses contextlib.asynccontextmanager after py36 being dropped
 attrs==21.4.0
 black==22.3.0
 flake8==3.9.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ packages = find:
 install_requires =
     aiohttp>=1.0.0
     attrs>=20.1
-python_requires = >=3.6
+python_requires = >=3.7
 include_package_data = True
 
 [options.packages.find]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import abc
 import asyncio
+import contextlib
 import inspect
 import os
 import shutil
@@ -8,7 +9,6 @@ import time
 from asyncio.subprocess import Process
 from typing import Awaitable, Callable, List, Optional, Sequence, Type, Union
 
-import async_generator
 import pytest
 
 from ansq.http import NSQDHTTPWriter, NsqLookupd
@@ -157,7 +157,7 @@ class NSQLookupD(BaseNSQServer):
 
 @pytest.fixture
 def create_nsqd(tmp_path):
-    @async_generator.asynccontextmanager
+    @contextlib.asynccontextmanager
     async def _create_nsqd(
         host="127.0.0.1",
         port=4150,
@@ -187,7 +187,7 @@ def create_nsqd(tmp_path):
 
 @pytest.fixture
 def create_nsqlookupd():
-    @async_generator.asynccontextmanager
+    @contextlib.asynccontextmanager
     async def _create_nsqlookupd(host="127.0.0.1", port=4160, http_port=4161):
         nsqlookupd = NSQLookupD(host=host, port=port, http_port=http_port)
         try:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py3{6,7,8,9,10,11}-cov
+    py3{7,8,9,10,11}-cov
     cov
     lint
 skip_missing_interpreters = True
@@ -21,7 +21,6 @@ commands = pre-commit run --all-files --show-diff-on-failure
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39


### PR DESCRIPTION
Python 3.6 is EOL since December 2021