### PR TITLE
Run test nsqd in a subprocess

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -12,15 +12,8 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.os }} / Python ${{ matrix.python-version }}
+    name: ${{ matrix.os }} / ${{ matrix.nsq-version }} / Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}-latest
-    services:
-      nsqd:
-        image: nsqio/nsq
-        options: --entrypoint /nsqd
-        ports:
-          - 4150:4150
-          - 4151:4151
     strategy:
       matrix:
         os:
@@ -29,11 +22,21 @@ jobs:
           - 3.6
           - 3.7
           - 3.8
+        nsq-version:
+          - "nsq-1.1.0.linux-amd64.go1.10.3"
+          - "nsq-1.2.0.linux-amd64.go1.12.9"
+          - "nsq-1.2.1.linux-amd64.go1.16.6"
     env:
       PY_COLORS: 1
       PYTEST_ADDOPTS: --cov-report=xml
     steps:
       - uses: actions/checkout@master
+      - name: Download NSQ
+        run: |
+          curl -sSL "http://bitly-downloads.s3.amazonaws.com/nsq/${{matrix.nsq-version}}.tar.gz" \
+                    | tar -xzv --strip-components=1
+          sudo ln -s ./bin/nsqd /bin/nsqd
+          ./bin/nsqd --version
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -43,7 +46,9 @@ jobs:
       - name: Prepare test environment
         run: tox --notest
       - name: Test
-        run: tox
+        run: |
+          export PATH=bin:$PATH
+          tox
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1.0.13
         with:

--- a/ansq/http/base.py
+++ b/ansq/http/base.py
@@ -1,5 +1,6 @@
+import asyncio
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 import aiohttp
 
@@ -16,9 +17,13 @@ class NSQHTTPConnection:
     """XXX"""
 
     def __init__(
-        self, host: str = "127.0.0.1", port: int = 4151, *, loop: "AbstractEventLoop",
+        self,
+        host: str = "127.0.0.1",
+        port: int = 4151,
+        *,
+        loop: Optional["AbstractEventLoop"] = None,
     ) -> None:
-        self._loop = loop
+        self._loop = loop or asyncio.get_event_loop()
         self._endpoint = (host, port)
         self._base_url = "http://{}:{}/".format(*self._endpoint)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 add-trailing-comma==2.0.1
 aiohttp==3.7.4
+async-generator==1.10  # TODO: uses contextlib.asynccontextmanager after py36 being dropped
 black==19.10b0
 flake8==3.8.3
 isort==5.4.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,116 @@
+import asyncio
+import os
+import shutil
+import signal
+import time
+from asyncio.subprocess import Process
+
+import async_generator
+import pytest
+
+from ansq.http import NSQDHTTPWriter
+
+pytestmark = pytest.mark.asyncio
+
+
+class AsyncNSQD:
+    """Simple async nsqd server. Requires installed nsqd binary."""
+
+    _process: Process
+
+    def __init__(
+        self,
+        host: str = "127.0.0.1",
+        port: int = 4150,
+        http_port: int = 4151,
+        data_path="/tmp",
+    ) -> None:
+        self.host = host
+        self.port = port
+        self.http_port = http_port
+        self.data_path = data_path
+        self._nsqd_command = "nsqd"
+
+        if shutil.which(self._nsqd_command) is None:
+            raise RuntimeError(
+                "nsqd must be installed. "
+                "Follow the instructions in the installing doc: "
+                "https://nsq.io/deployment/installing.html",
+            )
+
+    def __repr__(self):
+        return f"{type(self).__name__}({self.host!r}, {self.port})"
+
+    @property
+    def tcp_address(self) -> str:
+        return f"{self.host}:{self.port}"
+
+    @property
+    def http_address(self) -> str:
+        return f"{self.host}:{self.http_port}"
+
+    async def start(self):
+        """Start nsqd in a separate process."""
+        self._process = await asyncio.create_subprocess_exec(
+            self._nsqd_command,
+            "-tcp-address",
+            self.tcp_address,
+            "-http-address",
+            self.http_address,
+            "-data-path",
+            self.data_path,
+        )
+        await self._wait_ping()
+
+    async def stop(self):
+        """Stop nsqd."""
+        if not hasattr(self, "_process"):
+            return
+
+        os.kill(self._process.pid, signal.SIGKILL)
+        await self._process.wait()
+
+    async def _wait_ping(self, timeout: int = 3) -> None:
+        """Wait for successful ping to HTTP API, otherwise raise last exception."""
+        http_writer = NSQDHTTPWriter(host=self.host, port=self.http_port)
+        start = time.time()
+        while True:
+            try:
+                res = await http_writer.ping()
+            except Exception:
+                res = None
+
+            if res == "OK":
+                break
+
+            if time.time() - start > timeout:
+                raise
+
+            await asyncio.sleep(0.1)
+
+        await http_writer.close()
+
+
+@pytest.fixture
+def create_nsqd(tmp_path):
+    @async_generator.asynccontextmanager
+    async def _create_nsqd(host="127.0.0.1", port=4150, http_port=4151):
+        data_path = tmp_path / f"{host}:{port}"
+        data_path.mkdir(parents=True)
+
+        nsqd = AsyncNSQD(
+            host=host, port=port, http_port=http_port, data_path=str(data_path),
+        )
+        try:
+            await nsqd.start()
+            yield nsqd
+        finally:
+            await nsqd.stop()
+
+    return _create_nsqd
+
+
+@pytest.fixture(autouse=True)
+async def nsqd(create_nsqd) -> AsyncNSQD:
+    async with create_nsqd() as nsqd:
+        yield nsqd


### PR DESCRIPTION
Benefits:
- easier tests run - no need to run manually nsqd, just install it and you are ready to go
- run multiple nsqd servers simultaneously
- more control over nsqd process during tests - start/stop whenever you need to
- test multiple nsq versions in CI


This PR also would help with #39 to make integrational/functioanal tests for auto-reconnect feature and start/stop the server during the tests.