### PR TITLE
Refactor connection options and features into `attrs` classes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,6 @@ repos:
           tests/ |
           examples/
         )
+      additional_dependencies:
+        - "aiohttp>=1.0.0"
+        - "attrs>=21.4.0,<22.0.0"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,5 +34,5 @@ repos:
           examples/
         )
       additional_dependencies:
-        - "aiohttp>=1.0.0"
-        - "attrs>=21.4.0,<22.0.0"
+        - "aiohttp"
+        - "attrs"

--- a/ansq/__init__.py
+++ b/ansq/__init__.py
@@ -1,5 +1,13 @@
-from .tcp.connection import open_connection
+from .tcp.connection import ConnectionFeatures, ConnectionOptions, open_connection
 from .tcp.reader import create_reader
 from .tcp.writer import create_writer
 
-__all__ = ["tcp", "http", "open_connection", "create_reader", "create_writer"]
+__all__ = [
+    "ConnectionFeatures",
+    "ConnectionOptions",
+    "create_reader",
+    "create_writer",
+    "http",
+    "open_connection",
+    "tcp",
+]

--- a/ansq/tcp/connection.py
+++ b/ansq/tcp/connection.py
@@ -1,11 +1,9 @@
 import asyncio
 import json
-import logging
 import sys
 import warnings
-from asyncio.events import AbstractEventLoop
 from datetime import datetime, timezone
-from typing import Any, AsyncGenerator, Callable, Optional, Union
+from typing import Any, AsyncGenerator, Callable, Mapping, Optional, Union
 
 import attr
 
@@ -562,21 +560,8 @@ async def open_connection(
     host: str = "localhost",
     port: int = 4150,
     *,
-    connection_options: Optional[ConnectionOptions] = None,
-    message_queue: Optional[asyncio.Queue] = None,
-    on_message: Optional[Callable] = None,
-    on_exception: Optional[Callable] = None,
-    loop: Optional[AbstractEventLoop] = None,
-    auto_reconnect: bool = True,
-    heartbeat_interval: int = 30000,
-    feature_negotiation: bool = True,
-    tls_v1: bool = False,
-    snappy: bool = False,
-    deflate: bool = False,
-    deflate_level: int = 6,
-    sample_rate: int = 0,
-    debug: bool = False,
-    logger: Optional[logging.Logger] = None,
+    connection_options: ConnectionOptions = ConnectionOptions(),
+    **kwargs: Mapping[str, Any],
 ) -> NSQConnection:
     """A helper to create and open an `NSQConnection`.
 
@@ -585,25 +570,8 @@ async def open_connection(
     nsq = NSQConnection(
         host,
         port,
-        connection_options=connection_options
-        or ConnectionOptions(
-            message_queue=message_queue,
-            on_message=on_message,
-            on_exception=on_exception,
-            loop=loop,
-            auto_reconnect=auto_reconnect,
-            features=ConnectionFeatures(
-                deflate=deflate,
-                deflate_level=deflate_level,
-                feature_negotiation=feature_negotiation,
-                heartbeat_interval=heartbeat_interval,
-                sample_rate=sample_rate,
-                snappy=snappy,
-                tls_v1=tls_v1,
-            ),
-            debug=debug,
-            logger=logger,
-        ),
+        connection_options=connection_options,
+        **kwargs,
     )
     await nsq.connect()
     await nsq.identify()

--- a/ansq/tcp/connection.py
+++ b/ansq/tcp/connection.py
@@ -278,9 +278,8 @@ class NSQConnection(NSQConnectionBase):
         If any of `features`, `config`, `kwargs` exist features defined in `__init__`
         method will be ignored.
         """
-        if features is not None:
-            self._options.features = features
-        elif config is not None:
+        # handle deprecated args
+        if config is not None:
             if not isinstance(config, (dict, str)):
                 raise TypeError("Config should be dict type or str")
             warnings.warn(
@@ -291,7 +290,7 @@ class NSQConnection(NSQConnectionBase):
                 category=DeprecationWarning,
             )
             if isinstance(config, dict):
-                self._options.features = ConnectionFeatures(**config)
+                features = ConnectionFeatures(**config)
         elif kwargs:
             warnings.warn(
                 message=(
@@ -300,8 +299,13 @@ class NSQConnection(NSQConnectionBase):
                 ),
                 category=DeprecationWarning,
             )
-            self._options.features = ConnectionFeatures(**kwargs)
+            features = ConnectionFeatures(**kwargs)
 
+        # update options with features passed as arguments to this method
+        if features is not None:
+            self._options = attr.evolve(self._options, features=features)
+
+        # maybe handle `config` argument passed as a string
         if features is None and isinstance(config, str):
             features_data = config
         else:

--- a/ansq/tcp/connection.py
+++ b/ansq/tcp/connection.py
@@ -2,9 +2,12 @@ import asyncio
 import json
 import logging
 import sys
+import warnings
 from asyncio.events import AbstractEventLoop
 from datetime import datetime, timezone
 from typing import Any, AsyncGenerator, Callable, Optional, Union
+
+import attr
 
 from ansq.tcp import consts
 from ansq.tcp.exceptions import (
@@ -14,6 +17,8 @@ from ansq.tcp.exceptions import (
     get_exception,
 )
 from ansq.tcp.types import (
+    ConnectionFeatures,
+    ConnectionOptions,
     ConnectionStatus,
     NSQCommands,
     NSQErrorSchema,
@@ -261,17 +266,51 @@ class NSQConnection(NSQConnectionBase):
         return await future
 
     async def identify(
-        self, config: Optional[Union[dict, str]] = None, **kwargs: Any
+        self,
+        config: Optional[Union[dict, str]] = None,
+        *,
+        features: Optional[ConnectionFeatures] = None,
+        **kwargs: Any,
     ) -> TCPResponse:
-        if config and isinstance(config, (dict, str)):
-            raise TypeError("Config should be dict type or str")
+        """Executes `IDENTIFY` command.
 
-        if config or kwargs:
-            self._config = config or kwargs
-        config = json.dumps(self._config)
+        Connection features are being determined in the following order: `features`,
+        `config` (deprecated), `kwargs` (deprecated).
+
+        If any of `features`, `config`, `kwargs` exist features defined in `__init__`
+        method will be ignored.
+        """
+        if features is not None:
+            self._options.features = features
+        elif config is not None:
+            if not isinstance(config, (dict, str)):
+                raise TypeError("Config should be dict type or str")
+            warnings.warn(
+                message=(
+                    "`config` argument for `NSQConnection.identify` is deprecated: "
+                    "use `features` argument instead"
+                ),
+                category=DeprecationWarning,
+            )
+            if isinstance(config, dict):
+                self._options.features = ConnectionFeatures(**config)
+        elif kwargs:
+            warnings.warn(
+                message=(
+                    "Passing keyword arguments to `NSQConnection.identify` is "
+                    "deprecated: use `features` argument instead"
+                ),
+                category=DeprecationWarning,
+            )
+            self._options.features = ConnectionFeatures(**kwargs)
+
+        if features is None and isinstance(config, str):
+            features_data = config
+        else:
+            features_data = json.dumps(attr.asdict(self._options.features))
 
         response = await self.execute(
-            NSQCommands.IDENTIFY, data=config, callback=self._start_upgrading
+            NSQCommands.IDENTIFY, data=features_data, callback=self._start_upgrading
         )
 
         if response in (NSQCommands.OK, NSQCommands.OK.decode()):
@@ -523,10 +562,11 @@ async def open_connection(
     host: str = "localhost",
     port: int = 4150,
     *,
-    message_queue: asyncio.Queue = None,
-    on_message: Callable = None,
-    on_exception: Callable = None,
-    loop: AbstractEventLoop = None,
+    connection_options: Optional[ConnectionOptions] = None,
+    message_queue: Optional[asyncio.Queue] = None,
+    on_message: Optional[Callable] = None,
+    on_exception: Optional[Callable] = None,
+    loop: Optional[AbstractEventLoop] = None,
     auto_reconnect: bool = True,
     heartbeat_interval: int = 30000,
     feature_negotiation: bool = True,
@@ -536,25 +576,34 @@ async def open_connection(
     deflate_level: int = 6,
     sample_rate: int = 0,
     debug: bool = False,
-    logger: logging.Logger = None,
+    logger: Optional[logging.Logger] = None,
 ) -> NSQConnection:
+    """A helper to create and open an `NSQConnection`.
+
+    If `connection_options` is defined other keyword args are being ignored.
+    """
     nsq = NSQConnection(
         host,
         port,
-        message_queue=message_queue,
-        on_message=on_message,
-        on_exception=on_exception,
-        loop=loop,
-        auto_reconnect=auto_reconnect,
-        heartbeat_interval=heartbeat_interval,
-        feature_negotiation=feature_negotiation,
-        tls_v1=tls_v1,
-        snappy=snappy,
-        deflate=deflate,
-        deflate_level=deflate_level,
-        sample_rate=sample_rate,
-        debug=debug,
-        logger=logger,
+        connection_options=connection_options
+        or ConnectionOptions(
+            message_queue=message_queue,
+            on_message=on_message,
+            on_exception=on_exception,
+            loop=loop,
+            auto_reconnect=auto_reconnect,
+            features=ConnectionFeatures(
+                deflate=deflate,
+                deflate_level=deflate_level,
+                feature_negotiation=feature_negotiation,
+                heartbeat_interval=heartbeat_interval,
+                sample_rate=sample_rate,
+                snappy=snappy,
+                tls_v1=tls_v1,
+            ),
+            debug=debug,
+            logger=logger,
+        ),
     )
     await nsq.connect()
     await nsq.identify()

--- a/ansq/tcp/reader.py
+++ b/ansq/tcp/reader.py
@@ -183,7 +183,7 @@ class Lookupd:
         self._poll_lookup_task: Optional[asyncio.Task] = None
 
         # Keep original on close callback to call it in `self._on_close_connection`
-        self._reader_on_close = self._reader.connection_options.on_close
+        self._orig_on_close_callback = self._reader.connection_options.on_close
 
         # Configure connections specific for lookupd
         self._reader.connection_options = attr.evolve(
@@ -304,8 +304,8 @@ class Lookupd:
         self._reader.remove_connection(connection)
 
         # Call an original on_close callback if specified
-        if self._reader_on_close is not None:
-            self._reader_on_close(connection)
+        if self._orig_on_close_callback is not None:
+            self._orig_on_close_callback(connection)
 
 
 class Address(NamedTuple):

--- a/ansq/tcp/types/__init__.py
+++ b/ansq/tcp/types/__init__.py
@@ -1,19 +1,21 @@
 from .client import Client
 from .commands import NSQCommands
-from .connection import TCPConnection
+from .connection import ConnectionFeatures, ConnectionOptions, TCPConnection
 from .connection_status import ConnectionStatus
 from .frame_type import FrameType
 from .message import NSQMessage
 from .response_schemas import NSQErrorSchema, NSQMessageSchema, NSQResponseSchema
 
 __all__ = (
-    "TCPConnection",
-    "NSQMessage",
-    "NSQResponseSchema",
-    "NSQMessageSchema",
-    "NSQErrorSchema",
-    "FrameType",
-    "ConnectionStatus",
-    "NSQCommands",
     "Client",
+    "ConnectionFeatures",
+    "ConnectionOptions",
+    "ConnectionStatus",
+    "FrameType",
+    "NSQCommands",
+    "NSQErrorSchema",
+    "NSQMessage",
+    "NSQMessageSchema",
+    "NSQResponseSchema",
+    "TCPConnection",
 )

--- a/ansq/tcp/types/client.py
+++ b/ansq/tcp/types/client.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional, Sequence, Tuple
 
+import attr
+
 if TYPE_CHECKING:
     from ansq.tcp.connection import NSQConnection
 
@@ -10,15 +12,15 @@ class Client:
     def __init__(
         self,
         nsqd_tcp_addresses: Sequence[str],
-        connection_options: Optional[Mapping[str, Any]] = None,
+        connection_options: ConnectionOptions = ConnectionOptions(),
         debug: bool = False,
     ):
         self._nsqd_tcp_addresses = nsqd_tcp_addresses
-        self._orig_connection_options = connection_options or {}
-        self.connection_options = dict(self._orig_connection_options)
 
         if debug:
-            self.connection_options["debug"] = True
+            connection_options = attr.evolve(connection_options, debug=True)
+
+        self.connection_options = connection_options
 
         self._connections: Dict[str, NSQConnection] = {}
 

--- a/ansq/tcp/types/client.py
+++ b/ansq/tcp/types/client.py
@@ -1,6 +1,8 @@
-from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Dict, Sequence, Tuple
 
 import attr
+
+from ansq.tcp.types import ConnectionOptions
 
 if TYPE_CHECKING:
     from ansq.tcp.connection import NSQConnection
@@ -42,7 +44,9 @@ class Client:
         """Connect and identify to nsqd by given host and port."""
         from ansq.tcp.connection import NSQConnection
 
-        connection = NSQConnection(host=host, port=port, **self.connection_options)
+        connection = NSQConnection(
+            host=host, port=port, connection_options=self.connection_options
+        )
 
         existing_connection = self._connections.get(connection.id)
         if existing_connection is not None:

--- a/ansq/tcp/types/client.py
+++ b/ansq/tcp/types/client.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, Dict, Sequence, Tuple
 
 import attr
 
-from ansq.tcp.types import ConnectionOptions
+from .connection import ConnectionOptions
 
 if TYPE_CHECKING:
     from ansq.tcp.connection import NSQConnection

--- a/ansq/tcp/types/connection.py
+++ b/ansq/tcp/types/connection.py
@@ -6,16 +6,7 @@ from asyncio.events import AbstractEventLoop
 from asyncio.streams import StreamReader, StreamWriter
 from collections import deque
 from datetime import datetime
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Deque,
-    Mapping,
-    Optional,
-    Tuple,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, Deque, Mapping, Optional, Tuple, Union
 
 import attr
 
@@ -25,7 +16,7 @@ if TYPE_CHECKING:
     from ansq.tcp.types import ConnectionStatus, NSQMessage, NSQMessageSchema
 
 
-@attr.define(auto_attribs=True, kw_only=True)
+@attr.define(frozen=True, auto_attribs=True, kw_only=True)
 class ConnectionFeatures:
     deflate: bool = False
     deflate_level: int = 6
@@ -36,7 +27,7 @@ class ConnectionFeatures:
     tls_v1: bool = False
 
 
-@attr.define(auto_attribs=True, kw_only=True)
+@attr.define(frozen=True, auto_attribs=True, kw_only=True)
 class ConnectionOptions:
     message_queue: Optional["asyncio.Queue[Optional[NSQMessage]]"] = None
     # TODO: define more strict type for `on_message`
@@ -84,8 +75,9 @@ class TCPConnection(abc.ABC):
         if kwargs:
             warnings.warn(
                 message=(
-                    "Passing connection options to `TCPConnection` using keyword "
-                    "arguments is deprecated: use `ConnectionOptions` structure instead"
+                    f"Passing connection options to `{self.__class__.__name__}` using "
+                    "keyword arguments is deprecated: use `ConnectionOptions` "
+                    "structure instead"
                 ),
                 category=DeprecationWarning,
             )

--- a/ansq/tcp/writer.py
+++ b/ansq/tcp/writer.py
@@ -1,8 +1,8 @@
 import random
-from typing import TYPE_CHECKING, Any, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
 
 from ansq.tcp.connection import NSQConnection
-from ansq.tcp.types import Client
+from ansq.tcp.types import Client, ConnectionOptions
 
 if TYPE_CHECKING:
     from ansq.typedefs import TCPResponse
@@ -14,13 +14,11 @@ class Writer(Client):
     def __init__(
         self,
         nsqd_tcp_addresses: Sequence[str],
-        connection_options: Mapping[str, Any] = None,
-        debug: bool = False,
+        connection_options: ConnectionOptions = ConnectionOptions(),
     ):
         super().__init__(
             nsqd_tcp_addresses=nsqd_tcp_addresses,
             connection_options=connection_options,
-            debug=debug,
         )
 
         if not self._nsqd_tcp_addresses:
@@ -51,14 +49,11 @@ class Writer(Client):
 
 async def create_writer(
     nsqd_tcp_addresses: Sequence[str],
-    connection_options: Mapping[str, Any] = None,
-    debug: bool = False,
+    connection_options: ConnectionOptions = ConnectionOptions(),
 ) -> Writer:
     """Return created and connected writer."""
     writer = Writer(
-        nsqd_tcp_addresses=nsqd_tcp_addresses,
-        connection_options=connection_options,
-        debug=debug,
+        nsqd_tcp_addresses=nsqd_tcp_addresses, connection_options=connection_options
     )
     await writer.connect()
     return writer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,12 @@
-add-trailing-comma==2.0.1
 aiohttp==3.7.4
 async-generator==1.10  # TODO: uses contextlib.asynccontextmanager after py36 being dropped
-black==19.10b0
-flake8==3.8.3
-isort==5.4.2
-mypy==0.770
+black==22.3.0
+flake8==3.9.2
+isort==5.10.1
+mypy==0.942
 pytest==7.0.1
 pytest-asyncio==0.16.0
 pytest-cov==3.0.0
-pyupgrade==2.7.2
+pyupgrade==2.31.0
 tox==3.16.1
 wheel==0.34.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 aiohttp==3.7.4
 async-generator==1.10  # TODO: uses contextlib.asynccontextmanager after py36 being dropped
+attrs==21.4.0
 black==22.3.0
 flake8==3.9.2
 isort==5.10.1

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from setuptools import find_packages, setup
 PY_VER = sys.version_info
 install_requires = [
     "aiohttp>=1.0.0",
+    "attrs>=21.4.0,<22.0.0",
 ]
 
 classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@ import sys
 from setuptools import find_packages, setup
 
 PY_VER = sys.version_info
+
+# NOTE: keep this in sync with `additional_dependencies` in `.pre-commit-config.yaml`
 install_requires = [
     "aiohttp>=1.0.0",
     "attrs>=20.1",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 PY_VER = sys.version_info
 install_requires = [
     "aiohttp>=1.0.0",
-    "attrs>=21.4.0,<22.0.0",
+    "attrs>=20.1",
 ]
 
 classifiers = [

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ansq import open_connection
+from ansq import ConnectionOptions, open_connection
 
 
 @pytest.mark.asyncio
@@ -41,7 +41,9 @@ async def test_reconnect_while_connected():
 
 @pytest.mark.asyncio
 async def test_auto_reconnect(nsqd, wait_for):
-    nsq = await open_connection(auto_reconnect=True)
+    nsq = await open_connection(
+        connection_options=ConnectionOptions(auto_reconnect=True)
+    )
     assert nsq.status.is_connected
 
     await nsqd.stop()


### PR DESCRIPTION
Added `ConnectionOptions` and `ConnectionFeatures` `attrs` classes to allow reusing connection arguments in new `Reader` and `Writer` classes keeping type annotations as strict as possible.

This also simplifies the usage of those arguments in user-defined wrappers for these classes.