### PR TITLE
Add default tcp addresses to reader and writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ import asyncio
 
 async def main():
     reader = await ansq.create_reader(
-        nsqd_tcp_addresses=["127.0.0.1:4150"],
         topic="example_topic",
         channel="example_channel",
     )
@@ -68,7 +67,7 @@ import asyncio
 
 
 async def main():
-    writer = await ansq.create_writer(nsqd_tcp_addresses=["127.0.0.1:4150"])
+    writer = await ansq.create_writer()
     await writer.pub(
         topic="example_topic",
         message="Hello, world!",

--- a/ansq/tcp/reader.py
+++ b/ansq/tcp/reader.py
@@ -39,15 +39,16 @@ class Reader(Client):
         connection_options: ConnectionOptions = ConnectionOptions(),
         loop: AbstractEventLoop = None,
     ):
-        if not any((nsqd_tcp_addresses, lookupd_http_addresses)):
-            raise ValueError(
-                "nsqd_tcp_addresses or/and lookupd_http_addresses must be not empty",
-            )
+        if nsqd_tcp_addresses is None:
+            nsqd_tcp_addresses = []
 
         super().__init__(
             nsqd_tcp_addresses=nsqd_tcp_addresses or [],
             connection_options=connection_options,
         )
+
+        if not any((self._nsqd_tcp_addresses, lookupd_http_addresses)):
+            self._nsqd_tcp_addresses = ["localhost:4150"]
 
         self._topic = topic
         self._channel = channel
@@ -319,8 +320,8 @@ class Address(NamedTuple):
 async def create_reader(
     topic: str,
     channel: str,
-    nsqd_tcp_addresses: Sequence[str] = None,
-    lookupd_http_addresses: Sequence[str] = None,
+    nsqd_tcp_addresses: Optional[Sequence[str]] = None,
+    lookupd_http_addresses: Optional[Sequence[str]] = None,
     lookupd_poll_interval: float = 60000,
     lookupd_poll_jitter: float = 0.3,
     connection_options: ConnectionOptions = ConnectionOptions(),

--- a/ansq/tcp/writer.py
+++ b/ansq/tcp/writer.py
@@ -1,5 +1,5 @@
 import random
-from typing import TYPE_CHECKING, Any, Sequence
+from typing import TYPE_CHECKING, Any, Optional, Sequence
 
 from ansq.tcp.connection import NSQConnection
 from ansq.tcp.types import Client, ConnectionOptions
@@ -13,16 +13,16 @@ class Writer(Client):
 
     def __init__(
         self,
-        nsqd_tcp_addresses: Sequence[str],
+        nsqd_tcp_addresses: Optional[Sequence[str]] = None,
         connection_options: ConnectionOptions = ConnectionOptions(),
     ):
         super().__init__(
-            nsqd_tcp_addresses=nsqd_tcp_addresses,
+            nsqd_tcp_addresses=nsqd_tcp_addresses or [],
             connection_options=connection_options,
         )
 
         if not self._nsqd_tcp_addresses:
-            raise ValueError("nsqd_tcp_addresses must be not empty")
+            self._nsqd_tcp_addresses = ["localhost:4150"]
 
     async def pub(self, topic: str, message: Any) -> "TCPResponse":
         """Publish a message to a topic to a random connection."""
@@ -48,7 +48,7 @@ class Writer(Client):
 
 
 async def create_writer(
-    nsqd_tcp_addresses: Sequence[str],
+    nsqd_tcp_addresses: Optional[Sequence[str]] = None,
     connection_options: ConnectionOptions = ConnectionOptions(),
 ) -> Writer:
     """Return created and connected writer."""

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -13,9 +13,7 @@ async def nsqd2(tmp_path, create_nsqd):
 
 
 async def test_create_reader(nsqd):
-    reader = await create_reader(
-        topic="foo", channel="bar", nsqd_tcp_addresses=[nsqd.tcp_address]
-    )
+    reader = await create_reader(topic="foo", channel="bar")
 
     assert reader.topic == "foo"
     assert reader.channel == "bar"
@@ -25,7 +23,7 @@ async def test_create_reader(nsqd):
 
 
 async def test_connect_reader(nsqd):
-    reader = Reader(topic="foo", channel="bar", nsqd_tcp_addresses=[nsqd.tcp_address])
+    reader = Reader(topic="foo", channel="bar")
     assert not reader.connections
 
     await reader.connect()
@@ -36,9 +34,7 @@ async def test_connect_reader(nsqd):
 
 
 async def test_close_reader(nsqd):
-    reader = await create_reader(
-        topic="foo", channel="bar", nsqd_tcp_addresses=[nsqd.tcp_address]
-    )
+    reader = await create_reader(topic="foo", channel="bar")
     await reader.close()
 
     closed_connections = [conn for conn in reader.connections if conn.is_closed]
@@ -50,9 +46,7 @@ async def test_wait_for_message(nsqd):
     await nsq.pub(topic="foo", message="test_message")
     await nsq.close()
 
-    reader = await create_reader(
-        topic="foo", channel="bar", nsqd_tcp_addresses=[nsqd.tcp_address]
-    )
+    reader = await create_reader(topic="foo", channel="bar")
 
     message = await reader.wait_for_message()
     await message.fin()
@@ -67,9 +61,7 @@ async def test_messages_generator(nsqd):
     await nsq.pub(topic="foo", message="test_message2")
     await nsq.close()
 
-    reader = await create_reader(
-        topic="foo", channel="bar", nsqd_tcp_addresses=[nsqd.tcp_address]
-    )
+    reader = await create_reader(topic="foo", channel="bar")
 
     read_messages = []
     async for message in reader.messages():

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -13,7 +13,7 @@ async def nsqd2(tmp_path, create_nsqd):
 
 
 async def test_create_writer(nsqd):
-    writer = await create_writer(nsqd_tcp_addresses=[nsqd.tcp_address])
+    writer = await create_writer()
 
     open_connections = [conn for conn in writer.connections if conn.is_connected]
     assert len(open_connections) == 1
@@ -22,7 +22,7 @@ async def test_create_writer(nsqd):
 
 
 async def test_connect_writer(nsqd):
-    writer = Writer(nsqd_tcp_addresses=[nsqd.tcp_address])
+    writer = Writer()
     assert not writer.connections
 
     await writer.connect()
@@ -33,7 +33,7 @@ async def test_connect_writer(nsqd):
 
 
 async def test_close_writer(nsqd):
-    writer = await create_writer(nsqd_tcp_addresses=[nsqd.tcp_address])
+    writer = await create_writer()
     await writer.close()
 
     closed_connections = [conn for conn in writer.connections if conn.is_closed]
@@ -41,7 +41,7 @@ async def test_close_writer(nsqd):
 
 
 async def test_pub(nsqd):
-    writer = await create_writer(nsqd_tcp_addresses=[nsqd.tcp_address])
+    writer = await create_writer()
 
     response = await writer.pub(topic="foo", message="test_message")
     assert response.is_ok
@@ -50,7 +50,7 @@ async def test_pub(nsqd):
 
 
 async def test_mpub(nsqd):
-    writer = await create_writer(nsqd_tcp_addresses=[nsqd.tcp_address])
+    writer = await create_writer()
 
     messages = [f"test_message_{i}" for i in range(10)]
     response = await writer.mpub("foo", *messages)
@@ -60,7 +60,7 @@ async def test_mpub(nsqd):
 
 
 async def test_dpub(nsqd):
-    writer = await create_writer(nsqd_tcp_addresses=[nsqd.tcp_address])
+    writer = await create_writer()
 
     response = await writer.dpub(topic="foo", message="test_message", delay_time=1)
     assert response.is_ok


### PR DESCRIPTION
To keep in sync with `TCPConnection`: https://github.com/list-family/ansq/blob/bf170d16db2b1c418a522d10c732fe5afb5f8df5/ansq/tcp/types/connection.py#L60-L66