### PR TITLE
Disable scheduled tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -6,9 +6,6 @@ on:
     branches:
       - master
     tags:
-  schedule:
-    # Run everyday at 02:34 UTC
-    - cron: 34 2 * * *
 
 jobs:
   test:


### PR DESCRIPTION
Scheduled tests are useful if test against certain NSQ versions.
Don't waste CI time.