### PR TITLE
Do not autouse nsqd fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,7 +199,7 @@ def create_nsqlookupd():
     return _create_nsqlookupd
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 async def nsqd(create_nsqd) -> NSQD:
     async with create_nsqd() as nsqd:
         yield nsqd

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4,7 +4,7 @@ from ansq import ConnectionOptions, open_connection
 
 
 @pytest.mark.asyncio
-async def test_connection():
+async def test_connection(nsqd):
     nsq = await open_connection()
     assert nsq.status.is_connected
 
@@ -13,7 +13,7 @@ async def test_connection():
 
 
 @pytest.mark.asyncio
-async def test_reconnect_after_close():
+async def test_reconnect_after_close(nsqd):
     nsq = await open_connection()
     assert nsq.status.is_connected
 
@@ -28,7 +28,7 @@ async def test_reconnect_after_close():
 
 
 @pytest.mark.asyncio
-async def test_reconnect_while_connected():
+async def test_reconnect_while_connected(nsqd):
     nsq = await open_connection()
     assert nsq.status.is_connected
 

--- a/tests/test_http_writer.py
+++ b/tests/test_http_writer.py
@@ -4,7 +4,7 @@ from ansq.http.writer import NSQDHTTPWriter
 
 
 @pytest.fixture
-async def writer(event_loop):
+async def writer(event_loop, nsqd):
     http_writer = NSQDHTTPWriter(loop=event_loop)
     yield http_writer
     await http_writer.close()

--- a/tests/test_read_messages.py
+++ b/tests/test_read_messages.py
@@ -8,7 +8,7 @@ from ansq.tcp.types import NSQMessage
 
 
 @pytest.mark.asyncio
-async def test_read_message():
+async def test_read_message(nsqd):
     nsq = await open_connection()
     assert nsq.status.is_connected
 
@@ -32,7 +32,7 @@ async def test_read_message():
 
 
 @pytest.mark.asyncio
-async def test_read_message_and_req():
+async def test_read_message_and_req(nsqd):
     nsq = await open_connection()
     assert nsq.status.is_connected
 
@@ -56,7 +56,7 @@ async def test_read_message_and_req():
 
 
 @pytest.mark.asyncio
-async def test_read_message_and_touch():
+async def test_read_message_and_touch(nsqd):
     nsq = await open_connection()
     assert nsq.status.is_connected
 
@@ -85,7 +85,7 @@ async def test_read_message_and_touch():
 
 
 @pytest.mark.asyncio
-async def test_read_message_and_fin_twice():
+async def test_read_message_and_fin_twice(nsqd):
     nsq = await open_connection()
     assert nsq.status.is_connected
 
@@ -113,7 +113,7 @@ async def test_read_message_and_fin_twice():
 
 
 @pytest.mark.asyncio
-async def test_read_messages_via_generator():
+async def test_read_messages_via_generator(nsqd):
     nsq = await open_connection()
     assert nsq.status.is_connected
 
@@ -140,7 +140,7 @@ async def test_read_messages_via_generator():
 
 
 @pytest.mark.asyncio
-async def test_read_single_message_via_get_message():
+async def test_read_single_message_via_get_message(nsqd):
     nsq = await open_connection()
     assert nsq.status.is_connected
 
@@ -168,7 +168,7 @@ async def test_read_single_message_via_get_message():
 
 
 @pytest.mark.asyncio
-async def test_read_bytes_message():
+async def test_read_bytes_message(nsqd):
     nsq = await open_connection()
     assert nsq.status.is_connected
 

--- a/tests/test_send_commands.py
+++ b/tests/test_send_commands.py
@@ -9,7 +9,7 @@ from ansq.tcp.exceptions import ConnectionClosedError
 
 
 @pytest.mark.asyncio
-async def test_command_pub():
+async def test_command_pub(nsqd):
     nsq = await open_connection()
     assert nsq.status.is_connected
 
@@ -21,7 +21,7 @@ async def test_command_pub():
 
 
 @pytest.mark.asyncio
-async def test_command_pub_after_reconnect():
+async def test_command_pub_after_reconnect(nsqd):
     nsq = await open_connection()
     assert nsq.status.is_connected
 
@@ -39,7 +39,7 @@ async def test_command_pub_after_reconnect():
 
 
 @pytest.mark.asyncio
-async def test_command_mpub():
+async def test_command_mpub(nsqd):
     nsq = await open_connection()
     assert nsq.status.is_connected
 
@@ -53,7 +53,7 @@ async def test_command_mpub():
 
 
 @pytest.mark.asyncio
-async def test_command_without_identity():
+async def test_command_without_identity(nsqd):
     nsq = NSQConnection()
     await nsq.connect()
     assert nsq.status.is_connected
@@ -66,7 +66,7 @@ async def test_command_without_identity():
 
 
 @pytest.mark.asyncio
-async def test_command_without_connection():
+async def test_command_without_connection(nsqd):
     nsq = NSQConnection()
     assert nsq.status.is_init
 
@@ -80,7 +80,7 @@ async def test_command_without_connection():
 
 
 @pytest.mark.asyncio
-async def test_command_sub():
+async def test_command_sub(nsqd):
     nsq = NSQConnection()
     await nsq.connect()
     assert nsq.status.is_connected
@@ -93,7 +93,7 @@ async def test_command_sub():
 
 
 @pytest.mark.asyncio
-async def test_command_with_closed_connection():
+async def test_command_with_closed_connection(nsqd):
     nsq = await open_connection()
     await nsq.close()
 
@@ -102,7 +102,7 @@ async def test_command_with_closed_connection():
 
 
 @pytest.mark.asyncio
-async def test_command_with_concurrently_closed_connection():
+async def test_command_with_concurrently_closed_connection(nsqd):
     nsq = await open_connection()
 
     async def close():


### PR DESCRIPTION
This makes tests faster for those that might not need nsqd service.