### PR TITLE
Fix error on passing deprecated kwargs to `open_connection()`

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -54,3 +54,25 @@ async def test_auto_reconnect(nsqd, wait_for):
 
     await nsq.close()
     assert nsq.status.is_closed
+
+
+@pytest.mark.asyncio
+async def test_connection_options_as_kwargs(nsqd):
+    nsq = await open_connection(debug=True)
+    assert nsq._options.debug is True
+    await nsq.close()
+
+
+@pytest.mark.asyncio
+async def test_feature_options_as_kwargs(nsqd):
+    nsq = await open_connection(heartbeat_interval=30001)
+    assert nsq._options.features.heartbeat_interval == 30001
+    await nsq.close()
+
+
+@pytest.mark.asyncio
+async def test_invalid_kwarg(nsqd):
+    with pytest.raises(
+        TypeError, match="got an unexpected keyword argument: 'invalid_kwarg'"
+    ):
+        await open_connection(invalid_kwarg=1)


### PR DESCRIPTION
Fixes #64.