### PR TITLE
Add client_id/hostname/useragent to identify command

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ packages = find:
 install_requires =
     aiohttp>=1.0.0
     attrs>=20.1
+    importlib-metadata;python_version<"3.8"
 python_requires = >=3.7
 include_package_data = True
 


### PR DESCRIPTION
This info tremendously helps to identify consumers in nsqd logs and nsqdadmin UI.

For example:
> [nsqd] 2023/01/24 22:50:58.995942 INFO: [127.0.0.1:57107] IDENTIFY: {**ClientID:tugushev-laptop Hostname:tugushev-laptop.local** HeartbeatInterval:30000 OutputBufferSize:0 OutputBufferTimeout:0 FeatureNegotiation:true TLSv1:false Deflate:false DeflateLevel:6 Snappy:false SampleRate:0 **UserAgent:ansq/0.1.0** MsgTimeout:60000}