### PR TITLE
Do the enum variants lookup through the type, not the instance.

### DIFF
--- a/ansq/tcp/types/connection_status.py
+++ b/ansq/tcp/types/connection_status.py
@@ -11,27 +11,27 @@ class ConnectionStatus(Enum):
 
     @property
     def is_closed(self) -> bool:
-        return self == self.CLOSED
+        return self == ConnectionStatus.CLOSED
 
     @property
     def is_closing(self) -> bool:
-        return self == self.CLOSING
+        return self == ConnectionStatus.CLOSING
 
     @property
     def is_init(self) -> bool:
-        return self == self.INIT
+        return self == ConnectionStatus.INIT
 
     @property
     def is_connected(self) -> bool:
-        return self == self.CONNECTED
+        return self == ConnectionStatus.CONNECTED
 
     @property
     def is_subscribed(self) -> bool:
-        return self == self.SUBSCRIBED
+        return self == ConnectionStatus.SUBSCRIBED
 
     @property
     def is_reconnecting(self) -> bool:
-        return self == self.RECONNECTING
+        return self == ConnectionStatus.RECONNECTING
 
     def __bool__(self) -> bool:
         return not self.is_closed and not self.is_closing and not self.is_init

--- a/ansq/tcp/types/frame_type.py
+++ b/ansq/tcp/types/frame_type.py
@@ -8,12 +8,12 @@ class FrameType(Enum):
 
     @property
     def is_response(self) -> bool:
-        return self == self.RESPONSE
+        return self == FrameType.RESPONSE
 
     @property
     def is_error(self) -> bool:
-        return self == self.ERROR
+        return self == FrameType.ERROR
 
     @property
     def is_message(self) -> bool:
-        return self == self.MESSAGE
+        return self == FrameType.MESSAGE


### PR DESCRIPTION
In python `3.11` this is not legal anymore:
```python3
>>> import enum
>>> class F(enum.Enum):
...     foo = 0
... 
>>> f = F.foo
>>> f
<F.foo: 0>
>>> f.foo
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/magniff/.pyenv/versions/3.11.0b3/lib/python3.11/enum.py", line 198, in __get__
    raise AttributeError(
    ^^^^^^^^^^^^^^^^^^^^^
AttributeError: <enum 'F'> member has no attribute 'foo'
```